### PR TITLE
fixing gt3x_datapath so you can put an index that is not 1 and it wil…

### DIFF
--- a/R/gt3x_sample_data.R
+++ b/R/gt3x_sample_data.R
@@ -9,6 +9,7 @@
 #' \dontrun{
 #' dir <- gt3x_datapath()
 #' gt3x_filename <- gt3x_datapath(1)
+#' stopifnot(!is.na(gt3x_datapath(2)))
 #' }
 #'
 #' @family file manipulations
@@ -24,14 +25,14 @@ gt3x_datapath <- function(index = NULL, verbose = TRUE) {
   for (i in seq_along(filenames)) {
     if (!file.exists(file.path(datadir, filenames[i]))) {
       gt3x_download(
-        url = gt3x_url(i),
+        url = paste0(gt3x_dataurl(), "/", filenames[i], ".zip"),
         exdir = datadir,
         verbose = verbose)
     }
   }
   if (!is.null(index)) {
-    files <- list_gt3x(datadir)
-    return(files[index])
+    files <- file.path(datadir, filenames)
+    return(files)
   }
   datadir
 }
@@ -92,7 +93,7 @@ gt3x_url <- function(index = NULL, filename = NULL) {
 gt3x_dataurl <- function(
   version = "v1.0",
   baseurl = "https://github.com/THLfi/read.gt3x/releases/download") {
-  url <- file.path(baseurl, version)
+  url <- paste(baseurl, version, sep ="/")
   url
 }
 

--- a/man/gt3x_datapath.Rd
+++ b/man/gt3x_datapath.Rd
@@ -28,6 +28,7 @@ Path to read.gt3x package sample data
 \dontrun{
 dir <- gt3x_datapath()
 gt3x_filename <- gt3x_datapath(1)
+stopifnot(!is.na(gt3x_datapath(2)))
 }
 
 testthat::expect_error(gt3x_filename(100))


### PR DESCRIPTION
There was a little bug that if you used `gt3x_datapath(2)`, it would return `NA`.  I think ideally you'd be able to download just one file if you want and not only the first.