### PR TITLE
Batch loading

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,11 @@ Authors@R:
              family = "Bos",
              role = "ctb",
              email = "egpbos@gmail.com",
-             comment = c(ORCID = "0000-0002-6033-960X")))
+             comment = c(ORCID = "0000-0002-6033-960X")),
+      person(given = "Vincent",
+             family = "van Hees",
+             role = "ctb",
+             email = "v.vanhees@accelting.com"))
 Description: Implements a high performance C++ parser 
     for 'ActiGraph' 'GT3X'/'GT3X+' data format (with extension '.gt3x') 
     for 'accelerometer' samples. Activity samples can be easily read into a

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,12 @@ Authors@R:
              family = "Muschelli",
              role = "aut",
              email = "muschellij2@gmail.com",
-             comment = c(ORCID = "0000-0001-6469-1750")))
+             comment = c(ORCID = "0000-0001-6469-1750")),
+      person(given = "Patrick",
+             family = "Bos",
+             role = "ctb",
+             email = "egpbos@gmail.com",
+             comment = c(ORCID = "0000-0002-6033-960X")))
 Description: Implements a high performance C++ parser 
     for 'ActiGraph' 'GT3X'/'GT3X+' data format (with extension '.gt3x') 
     for 'accelerometer' samples. Activity samples can be easily read into a

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Imports:
     R.utils,
     tools
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Suggests: 
     knitr,
     rmarkdown,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# read.gt3x 1.1.2
+
+* Added batch-reading functionality, see #40
+
 # read.gt3x 1.1.1
 
 * Added extraction of features.

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -13,7 +13,6 @@ activityAsDataFrame <- function(m, time_index, start_time, divider) {
 #' @param scale_factor Scale factor for the activity samples.
 #' @param sample_rate sampling rate for activity samples.
 #' @param start_time starting time of the sample recording.
-#' @param use_batching whether to use batching or not (false by default)
 #' @param batch_begin first second in time relative to start of raw non-imputed recording to include in this batch
 #' @param batch_end last second in time relative to start of raw non-imputed recording to include in this batch
 #' @param verbose Print the parameters from the log.bin file and other messages?
@@ -25,8 +24,8 @@ activityAsDataFrame <- function(m, time_index, start_time, divider) {
 #' The matrix has attributes
 #' "time_index", "missingness", "start_time_log", "sample_rate", "impute_zeroes".
 #'
-parseGT3X <- function(filename, max_samples, scale_factor, sample_rate, start_time, use_batching = FALSE, batch_begin = 0L, batch_end = 0L, verbose = FALSE, debug = FALSE, impute_zeroes = FALSE) {
-    .Call('_read_gt3x_parseGT3X', PACKAGE = 'read.gt3x', filename, max_samples, scale_factor, sample_rate, start_time, use_batching, batch_begin, batch_end, verbose, debug, impute_zeroes)
+parseGT3X <- function(filename, max_samples, scale_factor, sample_rate, start_time, batch_begin = 0L, batch_end = 0L, verbose = FALSE, debug = FALSE, impute_zeroes = FALSE) {
+    .Call('_read_gt3x_parseGT3X', PACKAGE = 'read.gt3x', filename, max_samples, scale_factor, sample_rate, start_time, batch_begin, batch_end, verbose, debug, impute_zeroes)
 }
 
 #' Parse activity samples from a NHANES-GT3X file

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -13,6 +13,9 @@ activityAsDataFrame <- function(m, time_index, start_time, divider) {
 #' @param scale_factor Scale factor for the activity samples.
 #' @param sample_rate sampling rate for activity samples.
 #' @param start_time starting time of the sample recording.
+#' @param use_batching whether to use batching or not (false by default)
+#' @param batch_begin first record to include in this batch
+#' @param batch_end last record to include in this batch
 #' @param verbose Print the parameters from the log.bin file and other messages?
 #' @param impute_zeroes Impute zeros in case there are missingness?
 #' @param debug Print information for every activity second
@@ -22,8 +25,8 @@ activityAsDataFrame <- function(m, time_index, start_time, divider) {
 #' The matrix has attributes
 #' "time_index", "missingness", "start_time_log", "sample_rate", "impute_zeroes".
 #'
-parseGT3X <- function(filename, max_samples, scale_factor, sample_rate, start_time, verbose = FALSE, debug = FALSE, impute_zeroes = FALSE) {
-    .Call('_read_gt3x_parseGT3X', PACKAGE = 'read.gt3x', filename, max_samples, scale_factor, sample_rate, start_time, verbose, debug, impute_zeroes)
+parseGT3X <- function(filename, max_samples, scale_factor, sample_rate, start_time, use_batching = FALSE, batch_begin = 0L, batch_end = 0L, verbose = FALSE, debug = FALSE, impute_zeroes = FALSE) {
+    .Call('_read_gt3x_parseGT3X', PACKAGE = 'read.gt3x', filename, max_samples, scale_factor, sample_rate, start_time, use_batching, batch_begin, batch_end, verbose, debug, impute_zeroes)
 }
 
 #' Parse activity samples from a NHANES-GT3X file

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -14,8 +14,8 @@ activityAsDataFrame <- function(m, time_index, start_time, divider) {
 #' @param sample_rate sampling rate for activity samples.
 #' @param start_time starting time of the sample recording.
 #' @param use_batching whether to use batching or not (false by default)
-#' @param batch_begin first record to include in this batch
-#' @param batch_end last record to include in this batch
+#' @param batch_begin first second in time relative to start of raw non-imputed recording to include in this batch
+#' @param batch_end last second in time relative to start of raw non-imputed recording to include in this batch
 #' @param verbose Print the parameters from the log.bin file and other messages?
 #' @param impute_zeroes Impute zeros in case there are missingness?
 #' @param debug Print information for every activity second

--- a/R/readGT3X.R
+++ b/R/readGT3X.R
@@ -15,7 +15,7 @@ NULL
 #' @param imputeZeroes Impute zeros in case there are missingness?
 #' Default is FALSE, in which case
 #' the time series will be incomplete in case there is missingness.
-#' @param ... additional arguments to pass to \code{parseGT3X} C++ code
+#' @param ... additional arguments to pass to \code{parseGT3X} C++ code, e.g. batch-loading options as now documented in vignette "Batch loading a gt3x file"
 #' @param verbose print diagnostic messages
 #' @param cleanup should any unzipped files be deleted?
 #' @param add_light add light data to the `data.frame` if data exists in the

--- a/man/parseGT3X.Rd
+++ b/man/parseGT3X.Rd
@@ -10,6 +10,9 @@ parseGT3X(
   scale_factor,
   sample_rate,
   start_time,
+  use_batching = FALSE,
+  batch_begin = 0L,
+  batch_end = 0L,
   verbose = FALSE,
   debug = FALSE,
   impute_zeroes = FALSE
@@ -26,6 +29,12 @@ not data is found.}
 \item{sample_rate}{sampling rate for activity samples.}
 
 \item{start_time}{starting time of the sample recording.}
+
+\item{use_batching}{whether to use batching or not (false by default)}
+
+\item{batch_begin}{first record to include in this batch}
+
+\item{batch_end}{last record to include in this batch}
 
 \item{verbose}{Print the parameters from the log.bin file and other messages?}
 

--- a/man/parseGT3X.Rd
+++ b/man/parseGT3X.Rd
@@ -32,9 +32,9 @@ not data is found.}
 
 \item{use_batching}{whether to use batching or not (false by default)}
 
-\item{batch_begin}{first record to include in this batch}
+\item{batch_begin}{first second in time relative to start of raw non-imputed recording to include in this batch}
 
-\item{batch_end}{last record to include in this batch}
+\item{batch_end}{last second in time relative to start of raw non-imputed recording to include in this batch}
 
 \item{verbose}{Print the parameters from the log.bin file and other messages?}
 

--- a/man/parseGT3X.Rd
+++ b/man/parseGT3X.Rd
@@ -10,7 +10,6 @@ parseGT3X(
   scale_factor,
   sample_rate,
   start_time,
-  use_batching = FALSE,
   batch_begin = 0L,
   batch_end = 0L,
   verbose = FALSE,
@@ -29,8 +28,6 @@ not data is found.}
 \item{sample_rate}{sampling rate for activity samples.}
 
 \item{start_time}{starting time of the sample recording.}
-
-\item{use_batching}{whether to use batching or not (false by default)}
 
 \item{batch_begin}{first second in time relative to start of raw non-imputed recording to include in this batch}
 

--- a/man/read.gt3x.Rd
+++ b/man/read.gt3x.Rd
@@ -32,7 +32,7 @@ this finds where all 3 axes are zero.}
 
 \item{cleanup}{should any unzipped files be deleted?}
 
-\item{...}{additional arguments to pass to \code{parseGT3X} C++ code}
+\item{...}{additional arguments to pass to \code{parseGT3X} C++ code, e.g. batch-loading options as now documented in vignette "Batch loading a gt3x file"}
 
 \item{add_light}{add light data to the \code{data.frame} if data exists in the
 GT3X}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -25,8 +25,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // parseGT3X
-NumericMatrix parseGT3X(const char* filename, const int max_samples, const double scale_factor, const int sample_rate, const uint32_t start_time, const bool use_batching, const uint32_t batch_begin, const uint32_t batch_end, const bool verbose, const bool debug, const bool impute_zeroes);
-RcppExport SEXP _read_gt3x_parseGT3X(SEXP filenameSEXP, SEXP max_samplesSEXP, SEXP scale_factorSEXP, SEXP sample_rateSEXP, SEXP start_timeSEXP, SEXP use_batchingSEXP, SEXP batch_beginSEXP, SEXP batch_endSEXP, SEXP verboseSEXP, SEXP debugSEXP, SEXP impute_zeroesSEXP) {
+NumericMatrix parseGT3X(const char* filename, const int max_samples, const double scale_factor, const int sample_rate, const uint32_t start_time, const uint32_t batch_begin, const uint32_t batch_end, const bool verbose, const bool debug, const bool impute_zeroes);
+RcppExport SEXP _read_gt3x_parseGT3X(SEXP filenameSEXP, SEXP max_samplesSEXP, SEXP scale_factorSEXP, SEXP sample_rateSEXP, SEXP start_timeSEXP, SEXP batch_beginSEXP, SEXP batch_endSEXP, SEXP verboseSEXP, SEXP debugSEXP, SEXP impute_zeroesSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -35,13 +35,12 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const double >::type scale_factor(scale_factorSEXP);
     Rcpp::traits::input_parameter< const int >::type sample_rate(sample_rateSEXP);
     Rcpp::traits::input_parameter< const uint32_t >::type start_time(start_timeSEXP);
-    Rcpp::traits::input_parameter< const bool >::type use_batching(use_batchingSEXP);
     Rcpp::traits::input_parameter< const uint32_t >::type batch_begin(batch_beginSEXP);
     Rcpp::traits::input_parameter< const uint32_t >::type batch_end(batch_endSEXP);
     Rcpp::traits::input_parameter< const bool >::type verbose(verboseSEXP);
     Rcpp::traits::input_parameter< const bool >::type debug(debugSEXP);
     Rcpp::traits::input_parameter< const bool >::type impute_zeroes(impute_zeroesSEXP);
-    rcpp_result_gen = Rcpp::wrap(parseGT3X(filename, max_samples, scale_factor, sample_rate, start_time, use_batching, batch_begin, batch_end, verbose, debug, impute_zeroes));
+    rcpp_result_gen = Rcpp::wrap(parseGT3X(filename, max_samples, scale_factor, sample_rate, start_time, batch_begin, batch_end, verbose, debug, impute_zeroes));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -79,7 +78,7 @@ END_RCPP
 
 static const R_CallMethodDef CallEntries[] = {
     {"_read_gt3x_activityAsDataFrame", (DL_FUNC) &_read_gt3x_activityAsDataFrame, 4},
-    {"_read_gt3x_parseGT3X", (DL_FUNC) &_read_gt3x_parseGT3X, 11},
+    {"_read_gt3x_parseGT3X", (DL_FUNC) &_read_gt3x_parseGT3X, 10},
     {"_read_gt3x_parseActivityBin", (DL_FUNC) &_read_gt3x_parseActivityBin, 6},
     {"_read_gt3x_parseLuxBin", (DL_FUNC) &_read_gt3x_parseLuxBin, 5},
     {NULL, NULL, 0}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // activityAsDataFrame
 DataFrame activityAsDataFrame(NumericMatrix& m, NumericVector& time_index, double start_time, int divider);
 RcppExport SEXP _read_gt3x_activityAsDataFrame(SEXP mSEXP, SEXP time_indexSEXP, SEXP start_timeSEXP, SEXP dividerSEXP) {
@@ -20,8 +25,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // parseGT3X
-NumericMatrix parseGT3X(const char* filename, const int max_samples, const double scale_factor, const int sample_rate, const uint32_t start_time, const bool verbose, const bool debug, const bool impute_zeroes);
-RcppExport SEXP _read_gt3x_parseGT3X(SEXP filenameSEXP, SEXP max_samplesSEXP, SEXP scale_factorSEXP, SEXP sample_rateSEXP, SEXP start_timeSEXP, SEXP verboseSEXP, SEXP debugSEXP, SEXP impute_zeroesSEXP) {
+NumericMatrix parseGT3X(const char* filename, const int max_samples, const double scale_factor, const int sample_rate, const uint32_t start_time, const bool use_batching, const uint32_t batch_begin, const uint32_t batch_end, const bool verbose, const bool debug, const bool impute_zeroes);
+RcppExport SEXP _read_gt3x_parseGT3X(SEXP filenameSEXP, SEXP max_samplesSEXP, SEXP scale_factorSEXP, SEXP sample_rateSEXP, SEXP start_timeSEXP, SEXP use_batchingSEXP, SEXP batch_beginSEXP, SEXP batch_endSEXP, SEXP verboseSEXP, SEXP debugSEXP, SEXP impute_zeroesSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -30,10 +35,13 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const double >::type scale_factor(scale_factorSEXP);
     Rcpp::traits::input_parameter< const int >::type sample_rate(sample_rateSEXP);
     Rcpp::traits::input_parameter< const uint32_t >::type start_time(start_timeSEXP);
+    Rcpp::traits::input_parameter< const bool >::type use_batching(use_batchingSEXP);
+    Rcpp::traits::input_parameter< const uint32_t >::type batch_begin(batch_beginSEXP);
+    Rcpp::traits::input_parameter< const uint32_t >::type batch_end(batch_endSEXP);
     Rcpp::traits::input_parameter< const bool >::type verbose(verboseSEXP);
     Rcpp::traits::input_parameter< const bool >::type debug(debugSEXP);
     Rcpp::traits::input_parameter< const bool >::type impute_zeroes(impute_zeroesSEXP);
-    rcpp_result_gen = Rcpp::wrap(parseGT3X(filename, max_samples, scale_factor, sample_rate, start_time, verbose, debug, impute_zeroes));
+    rcpp_result_gen = Rcpp::wrap(parseGT3X(filename, max_samples, scale_factor, sample_rate, start_time, use_batching, batch_begin, batch_end, verbose, debug, impute_zeroes));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -71,7 +79,7 @@ END_RCPP
 
 static const R_CallMethodDef CallEntries[] = {
     {"_read_gt3x_activityAsDataFrame", (DL_FUNC) &_read_gt3x_activityAsDataFrame, 4},
-    {"_read_gt3x_parseGT3X", (DL_FUNC) &_read_gt3x_parseGT3X, 8},
+    {"_read_gt3x_parseGT3X", (DL_FUNC) &_read_gt3x_parseGT3X, 11},
     {"_read_gt3x_parseActivityBin", (DL_FUNC) &_read_gt3x_parseActivityBin, 6},
     {"_read_gt3x_parseLuxBin", (DL_FUNC) &_read_gt3x_parseLuxBin, 5},
     {NULL, NULL, 0}

--- a/src/parseGT3X.cpp
+++ b/src/parseGT3X.cpp
@@ -319,7 +319,6 @@ int bytes2samplesize(uint8_t& type, uint16_t& bytes) {
 //' @param scale_factor Scale factor for the activity samples.
 //' @param sample_rate sampling rate for activity samples.
 //' @param start_time starting time of the sample recording.
-//' @param use_batching whether to use batching or not (false by default)
 //' @param batch_begin first second in time relative to start of raw non-imputed recording to include in this batch
 //' @param batch_end last second in time relative to start of raw non-imputed recording to include in this batch
 //' @param verbose Print the parameters from the log.bin file and other messages?
@@ -337,7 +336,6 @@ NumericMatrix parseGT3X(const char* filename,
                         const double scale_factor,
                         const int sample_rate,
                         const uint32_t start_time,
-                        const bool use_batching = false,
                         const uint32_t batch_begin = 0,
                         const uint32_t batch_end = 0,
                         const bool verbose = false,
@@ -366,7 +364,7 @@ NumericMatrix parseGT3X(const char* filename,
   bool have_activity2 = false;
   int num_activity = 0;
   int num_activity2 = 0;
-
+  bool use_batching = false;
   int chksum;
 
   if (debug) {
@@ -374,6 +372,10 @@ NumericMatrix parseGT3X(const char* filename,
   }
 
   uint32_t batch_counter = 0;
+
+  if (batch_begin != 0 || batch_end != 0) {
+    use_batching = true;
+  }
 
   while(GT3Xstream) {
 

--- a/src/parseGT3X.cpp
+++ b/src/parseGT3X.cpp
@@ -373,7 +373,7 @@ NumericMatrix parseGT3X(const char* filename,
 
   uint32_t batch_counter = 0;
 
-  if (batch_begin != 0 || batch_end != 0) {
+  if (batch_end != 0) {
     use_batching = true;
   }
 

--- a/src/parseGT3X.cpp
+++ b/src/parseGT3X.cpp
@@ -375,6 +375,9 @@ NumericMatrix parseGT3X(const char* filename,
 
   if (batch_end > 0) {
     use_batching = true;
+    if (batch_end < batch_begin) {
+      Rcout << "batch_begin is higher than batch_end, please check input arguments\n";
+    }
   }
 
   while(GT3Xstream) {

--- a/src/parseGT3X.cpp
+++ b/src/parseGT3X.cpp
@@ -320,8 +320,8 @@ int bytes2samplesize(uint8_t& type, uint16_t& bytes) {
 //' @param sample_rate sampling rate for activity samples.
 //' @param start_time starting time of the sample recording.
 //' @param use_batching whether to use batching or not (false by default)
-//' @param batch_begin first record to include in this batch
-//' @param batch_end last record to include in this batch
+//' @param batch_begin first second in time relative to start of raw non-imputed recording to include in this batch
+//' @param batch_end last second in time relative to start of raw non-imputed recording to include in this batch
 //' @param verbose Print the parameters from the log.bin file and other messages?
 //' @param impute_zeroes Impute zeros in case there are missingness?
 //' @param debug Print information for every activity second

--- a/src/parseGT3X.cpp
+++ b/src/parseGT3X.cpp
@@ -373,7 +373,7 @@ NumericMatrix parseGT3X(const char* filename,
 
   uint32_t batch_counter = 0;
 
-  if (batch_end != 0) {
+  if (batch_end > 0) {
     use_batching = true;
   }
 

--- a/src/parseGT3X.cpp
+++ b/src/parseGT3X.cpp
@@ -431,7 +431,7 @@ NumericMatrix parseGT3X(const char* filename,
           } else {
             Missingness[patch::to_string(expected_payload_start)] = n_missing;
 
-            if(impute_zeroes) {
+            if(impute_zeroes && !use_batching) {
               ImputeZeroes(timeStamps, total_records, n_missing, sample_rate, start_time, expected_payload_start, debug);
               total_records += n_missing;
             }
@@ -454,7 +454,7 @@ NumericMatrix parseGT3X(const char* filename,
             Rcout << "max_samples: " << max_samples << "\n";
           }
           Missingness[patch::to_string(payload_start)] = sample_rate;
-          if(impute_zeroes) {
+          if(impute_zeroes && !use_batching) {
             ImputeZeroes(timeStamps, total_records, sample_rate, sample_rate, start_time, payload_start, debug);
             total_records += sample_rate;
           }
@@ -511,7 +511,7 @@ NumericMatrix parseGT3X(const char* filename,
   scaleAndRoundActivity(activityMatrix, scale_factor, total_records);
 
 
-  if(!impute_zeroes) {
+  if(!impute_zeroes || use_batching) {
     if(verbose)
       Rcout << "Removing excess rows \n";
     activityMatrix =  activityMatrix(Range(0, total_records - 1), Range(0, N_ACTIVITYCOLUMNS - 1));

--- a/tests/testthat/test-read_MRA.R
+++ b/tests/testthat/test-read_MRA.R
@@ -3,6 +3,40 @@ url <- paste0("https://ndownloader.figshare.com/files/25557302")
 path <- tempfile(fileext = ".gt3x.gz")
 dl <- utils::download.file(url, destfile = path, mode = "wb")
 
+destroy_field = function(path, field = "Acceleration Scale",
+                         replace_field = list()) {
+  path <- read.gt3x:::unzip_zipped_gt3x(path, cleanup = TRUE)
+
+  tdir = tempfile()
+  out = unzip(path, exdir = tdir, overwrite = TRUE)
+  info_file = out[grepl("info.txt", out)]
+
+  if (all(field %in% "all")) {
+    out = out[!grepl("info.txt", out)]
+  } else {
+    info = readLines(info_file)
+    info
+    keys = sapply(strsplit(info, split = ":"), `[`, 1)
+    info = info[!keys %in% field]
+    if (length(replace_field) >0) {
+      for (ifield in seq_along(replace_field)) {
+        n =  names(replace_field)[ifield]
+        ind = which(keys == n)
+        info[ind] = paste0(n, ": ", replace_field[[ifield]])
+      }
+    }
+    writeLines(info, info_file)
+  }
+  new_gt3x_file = tempfile(fileext = ".gt3x")
+  if (requireNamespace("zip", quietly = TRUE)) {
+    zip::zip(files = basename(out),
+             zipfile = new_gt3x_file,
+             root = tdir,
+             include_directories = FALSE)
+  }
+  return(new_gt3x_file)
+}
+
 testthat::test_that("Reading in Old MRA", {
   testthat::expect_error({
     res <- read.gt3x::read.gt3x(path = character(0))

--- a/tests/testthat/test_read_new.R
+++ b/tests/testthat/test_read_new.R
@@ -99,15 +99,28 @@ testthat::test_that("Removing the gt3x works fine", {
 
 gt3xdata_full_no_zeroes <- read.gt3x(gt3xfile, asDataFrame = TRUE)
 gt3xdata_one_record_batch <- read.gt3x(gt3xfile, asDataFrame = TRUE,
-                                       use_batching = TRUE, batch_begin=1, batch_end=1)
+                                       batch_begin=1, batch_end=1)
 
 testthat::test_that("read.gt3x reads a single record batch correctly", {
   testthat::expect_true(nrow(gt3xdata_one_record_batch) == 100)
   testthat::expect_true(all(gt3xdata_one_record_batch[1:100,] == gt3xdata_full_no_zeroes[1:100,]))
 })
 
+
+gt3xdata_forget_batch_end <- read.gt3x(gt3xfile, asDataFrame = TRUE, batch_begin=100)
+
+testthat::test_that("read.gt3x reads entire file when forgetting to set batch_end", {
+  testthat::expect_equal(nrow(gt3xdata_forget_batch_end), 33000)
+})
+
+gt3xdata_forget_batch_begin <- read.gt3x(gt3xfile, asDataFrame = TRUE, batch_end=2)
+
+testthat::test_that("read.gt3x reads from batch 0 when forgetting to set batch_begin", {
+  testthat::expect_equal(nrow(gt3xdata_forget_batch_begin), 200)
+})
+
 gt3xdata_bigger_batch <- read.gt3x(gt3xfile, asDataFrame = TRUE,
-                                   use_batching = TRUE, batch_begin=11, batch_end=20)
+                                   batch_begin=11, batch_end=20)
 
 testthat::test_that("read.gt3x reads a bigger batch from somewhere in the file correctly", {
   testthat::expect_true(nrow(gt3xdata_bigger_batch) == 1000)
@@ -118,7 +131,7 @@ batch_size <- nrow(gt3xdata_one_record_batch)
 total_rows <- nrow(gt3xdata_full_no_zeroes)
 n_batches <- total_rows %/% batch_size
 gt3xdata_last_batch <- read.gt3x(gt3xfile, asDataFrame = TRUE,
-                                 use_batching = TRUE, batch_begin=n_batches, batch_end=n_batches)
+                                 batch_begin=n_batches, batch_end=n_batches)
 
 testthat::test_that("read.gt3x reads a batch at the end of the file correctly", {
   testthat::expect_true(all(gt3xdata_last_batch[1:100,] == gt3xdata_full_no_zeroes[(batch_size*(n_batches-1) + 1):(batch_size*(n_batches-1)+100),]))
@@ -133,7 +146,7 @@ testthat::test_that("read.gt3x reads a batch at the end of the file correctly", 
 # batching, as confirmed by the following test:
 
 gt3xdata_batch_impute <- read.gt3x(gt3xfile, asDataFrame = TRUE, imputeZeroes=TRUE,
-                                   use_batching = TRUE, batch_begin=11, batch_end=20)
+                                   batch_begin = 11, batch_end = 20)
 
 testthat::test_that("read.gt3x disables imputing zeroes when using batching", {
   testthat::expect_true(nrow(gt3xdata_batch_impute) == nrow(gt3xdata_bigger_batch))

--- a/tests/testthat/test_read_new.R
+++ b/tests/testthat/test_read_new.R
@@ -129,3 +129,13 @@ testthat::test_that("read.gt3x reads a batch at the end of the file correctly", 
 # Also, the batch counter currently only counts non-empty records, so comparing
 # to a dataframe with impute_zeros (like gt3xdata_full) has to be done on a row
 # by row basis, avoiding the zeroed rows.
+# Therefore, for the time being, imputing zeroes is disabled when using
+# batching, as confirmed by the following test:
+
+gt3xdata_batch_impute <- read.gt3x(gt3xfile, asDataFrame = TRUE, imputeZeroes=TRUE,
+                                   use_batching = TRUE, batch_begin=11, batch_end=20)
+
+testthat::test_that("read.gt3x disables imputing zeroes when using batching", {
+  testthat::expect_true(nrow(gt3xdata_batch_impute) == nrow(gt3xdata_bigger_batch))
+  testthat::expect_true(all(gt3xdata_bigger_batch[1:100,] == gt3xdata_batch_impute[1:100,]))
+})

--- a/tests/testthat/test_read_new.R
+++ b/tests/testthat/test_read_new.R
@@ -96,3 +96,36 @@ testthat::test_that("Removing the gt3x works fine", {
   }, "Unzipping faile")
   testthat::expect_null(res)
 })
+
+gt3xdata_full_no_zeroes <- read.gt3x(gt3xfile, asDataFrame = TRUE)
+gt3xdata_one_record_batch <- read.gt3x(gt3xfile, asDataFrame = TRUE,
+                                       use_batching = TRUE, batch_begin=1, batch_end=1)
+
+testthat::test_that("read.gt3x reads a single record batch correctly", {
+  testthat::expect_true(nrow(gt3xdata_one_record_batch) == 100)
+  testthat::expect_true(all(gt3xdata_one_record_batch[1:100,] == gt3xdata_full_no_zeroes[1:100,]))
+})
+
+gt3xdata_bigger_batch <- read.gt3x(gt3xfile, asDataFrame = TRUE,
+                                   use_batching = TRUE, batch_begin=11, batch_end=20)
+
+testthat::test_that("read.gt3x reads a bigger batch from somewhere in the file correctly", {
+  testthat::expect_true(nrow(gt3xdata_bigger_batch) == 1000)
+  testthat::expect_true(all(gt3xdata_bigger_batch[1:100,] == gt3xdata_full_no_zeroes[1001:1100,]))
+})
+
+batch_size <- nrow(gt3xdata_one_record_batch)
+total_rows <- nrow(gt3xdata_full_no_zeroes)
+n_batches <- total_rows %/% batch_size
+gt3xdata_last_batch <- read.gt3x(gt3xfile, asDataFrame = TRUE,
+                                 use_batching = TRUE, batch_begin=n_batches, batch_end=n_batches)
+
+testthat::test_that("read.gt3x reads a batch at the end of the file correctly", {
+  testthat::expect_true(all(gt3xdata_last_batch[1:100,] == gt3xdata_full_no_zeroes[(batch_size*(n_batches-1) + 1):(batch_size*(n_batches-1)+100),]))
+})
+
+# Batching doesn't work well with impute_zeros yet; that option automatically
+# makes the dataframe size the full size, which doesn't make sense for batching.
+# Also, the batch counter currently only counts non-empty records, so comparing
+# to a dataframe with impute_zeros (like gt3xdata_full) has to be done on a row
+# by row basis, avoiding the zeroed rows.

--- a/vignettes/batch_loading_gt3x.Rmd
+++ b/vignettes/batch_loading_gt3x.Rmd
@@ -1,0 +1,78 @@
+---
+title: "Batch loading a gt3x file"
+author: "Vincent van Hees"
+date: "`r Sys.Date()`"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Batch loading a gt3x file}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+  
+```{r setup, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+This document describes how the **read.gt3x** package can be used to read the newer .gt3x format files (firmware version above 2.5.0) in batches. For a general introduction about the read.gt3x package please see the [Getting started vignette](https://cran.rstudio.com/web/packages/read.gt3x/vignettes/read_gt3x.html). 
+
+## Purpose of batch-loading
+
+By batch-loading we mean the loading of a specific time segment from a file. Batch-loadings becomes relevant when working with your data poses memory problems for your machine (computer). For example, if you want to process a 7 days of 100 Hertz recording on a 8GB memory machine and apply a memory hungry algorithm to it then your machine may run out of memory. 
+
+## How to use batch-loading?
+
+In line with the [Getting started vignette](https://cran.rstudio.com/web/packages/read.gt3x/vignettes/read_gt3x.html) we start by loading the read.gt3x library and obtain the long example file:
+  
+```{r, eval = FALSE}
+library(read.gt3x)
+gt3xfile <- gt3x_datapath(1) # this downloads a long recording
+```
+
+To read a batch from this file we need to add two arguments to the read.gt3x function call:
+  
+- **batch_begin** First second in time relative to start of raw non-imputed recording to include in this batch
+- **batch_end** Last second in time relative to start of raw non-imputed recording to include in this batch
+
+The following example demonstrates how to use this functionality to iteratively read 24 hour batches from the recording we just downloaded.
+
+```{r, eval = FALSE}
+  N = 24 * 3600 # batch size in seconds (24 hours x 3600 seconds per hour)
+  i = 1
+  while (i > 0) {
+    cat("\nload batch #", i)
+    try(expr = {
+      batch_data = read.gt3x(gt3xfile,
+                             batch_begin = 1 + ((i - 1) * N),
+                             batch_end = i * N)
+    }, silent = TRUE)
+    if (exists("batch_data")) {
+      # <= Insert your memory hungry algorithm
+      # <= Do not forget to store the output of the algorithm somewhere
+      rm(batch_data) # <= remote the batch_data object to free up memory for the next batch
+    } else {
+      break() # end while loop when no more batches can be extracted
+    }
+    i = i + 1
+  }
+}
+```
+
+## Some notes on expected behaviour
+
+When argument batch_begin or batch_end are used argument **imputeZeroes** is currently automatically set to FALSE. This means that you as user will be responsible for imputing potential time gaps if idle sleep mode was turned on.
+
+batch_begin | batch_end | behaviour
+----------- | --------- | ---------------
+not provided | not provided | default behaviour, read.gt3x attempts to read the entire file
+not provided | second (in time) in the recording and higher than batch_begin | batch is read from beginning of the recording to batch_end
+second (in time) in the recording | second in the recording and higher than batch_begin | batch is read from batch_begin to batch_end
+second in the recording | second in the recording and less than batch_begin | no output and error message "batch_begin is higher than batch_end, please check input arguments"
+second in the recording | second after the end of the recording | batch is read from batch_begin until the end of the recording
+negative value | second in the recording | no output and error message "batch_begin is higher than batch_end, please check input arguments" this is because the code assumes a positive number and treats it as an unsigned 32 bit integer.
+
+## Where in the code can I find the batch-loading implementation?
+
+The batch-loading functionality is implemented in a C++ function called **parseGT3X**, which is used by function **read.gt3x**. The two arguments related to the batch-loading are forwarded by read.gt3x to parseGT3X. In this way the documentation function read.gt3x remains simple and applicable to all read.gt3x users. The specific functionality described in this vignette should be seen as an advanced option only relevant for those who work with modern .gt3x data.

--- a/vignettes/batch_loading_gt3x.Rmd
+++ b/vignettes/batch_loading_gt3x.Rmd
@@ -20,7 +20,7 @@ This document describes how the **read.gt3x** package can be used to read the ne
 
 ## Purpose of batch-loading
 
-By batch-loading we mean the loading of a specific time segment from a file. Batch-loadings becomes relevant when working with your data poses memory problems for your machine (computer). For example, if you want to process a 7 days of 100 Hertz recording on a 8GB memory machine and apply a memory hungry algorithm to it then your machine may run out of memory. 
+By batch-loading we mean the loading of a specific time segment from a file. Batch-loading becomes relevant when you face memory problems for your machine (computer). For example, if you want to process a 7 day with 100 Hertz recording on a 8GB memory machine and apply a memory hungry algorithm to it. Processing the data in batches is then the solution.
 
 ## How to use batch-loading?
 
@@ -31,27 +31,28 @@ library(read.gt3x)
 gt3xfile <- gt3x_datapath(1) # this downloads a long recording
 ```
 
-To read a batch from this file we need to add two arguments to the read.gt3x function call:
+To read a batch from this file we need to add two arguments to the `read.gt3x()` function call:
   
-- **batch_begin** First second in time relative to start of raw non-imputed recording to include in this batch
-- **batch_end** Last second in time relative to start of raw non-imputed recording to include in this batch
+- `batch_begin`: First second in time relative to start of raw non-imputed recording to include in this batch
+- `batch_end`: Last second in time relative to start of raw non-imputed recording to include in this batch
 
 The following example demonstrates how to use this functionality to iteratively read 24 hour batches from the recording we just downloaded.
 
 ```{r, eval = FALSE}
-  N = 24 * 3600 # batch size in seconds (24 hours x 3600 seconds per hour)
+  N = 24 * 3600 # batch size in seconds (24 hours per day x 3600 seconds per hour)
   i = 1
   while (i > 0) {
-    cat("\nload batch #", i)
     try(expr = {
       batch_data = read.gt3x(gt3xfile,
                              batch_begin = 1 + ((i - 1) * N),
                              batch_end = i * N)
     }, silent = TRUE)
     if (exists("batch_data")) {
-      # <= Insert your memory hungry algorithm
-      # <= Do not forget to store the output of the algorithm somewhere
-      rm(batch_data) # <= remote the batch_data object to free up memory for the next batch
+      cat("\nbatch #", i, "loaded with", nrow(batch_data),"rows")
+      # ... <= Insert your memory hungry algorithm
+      # ... <= Do not forget to store the output of your memory hungry algorithm somewhere
+      
+      rm(batch_data) # <= remove the batch_data object to free up memory before loading the next batch
     } else {
       break() # end while loop when no more batches can be extracted
     }
@@ -66,13 +67,15 @@ When argument batch_begin or batch_end are used argument **imputeZeroes** is cur
 
 batch_begin | batch_end | behaviour
 ----------- | --------- | ---------------
-not provided | not provided | default behaviour, read.gt3x attempts to read the entire file
-not provided | second (in time) in the recording and higher than batch_begin | batch is read from beginning of the recording to batch_end
+not provided | not provided | default behaviour, read.gt3x attempts to read the content of the entire file in memory
+not provided | second (in time) in the recording and higher than batch_begin | batch is read from beginning of the recording because batch_begin is not specified and defaults to the beginning all the way to batch_end
 second (in time) in the recording | second in the recording and higher than batch_begin | batch is read from batch_begin to batch_end
 second in the recording | second in the recording and less than batch_begin | no output and error message "batch_begin is higher than batch_end, please check input arguments"
-second in the recording | second after the end of the recording | batch is read from batch_begin until the end of the recording
-negative value | second in the recording | no output and error message "batch_begin is higher than batch_end, please check input arguments" this is because the code assumes a positive number and treats it as an unsigned 32 bit integer.
+second in the recording | value higher than the number of seconds in the recording | batch is read from batch_begin until the end of the recording
+negative value | second in the recording | no output and error message "batch_begin is higher than batch_end, please check input arguments" this is because the code expects a positive value and treats it as an unsigned 32 bit integer.
+
+
 
 ## Where in the code can I find the batch-loading implementation?
 
-The batch-loading functionality is implemented in a C++ function called **parseGT3X**, which is used by function **read.gt3x**. The two arguments related to the batch-loading are forwarded by read.gt3x to parseGT3X. In this way the documentation function read.gt3x remains simple and applicable to all read.gt3x users. The specific functionality described in this vignette should be seen as an advanced option only relevant for those who work with modern .gt3x data.
+The batch-loading functionality is implemented in a C++ function called **parseGT3X**, which is used by function **read.gt3x**. Argument batch_begin and batch_end are forwarded by read.gt3x to parseGT3X. In this way the documentation for function read.gt3x is applicable to all read.gt3x users, while this vignette describes the added functionality only relevant to modern .gt3x data owners interested in batch-loading the data.


### PR DESCRIPTION
This PR adds the possibility to load gt3x files in batches. This can be used to circumvent issues with running out of memory. It thus provides a solution to the problems discussed in https://github.com/wadpac/GGIR/issues/87.

The solution is simply to add three parameters:

1. `use_batching` is a boolean that switches on batching mode. Note that this also disables imputeZeroes, even if it is set to `TRUE` by the user. This is because the combination of these two options would add a lot of extra bookkeeping to the code. Apart from going beyond the scope of this PR, I thought it also might not be desired from a maintainability point of view.
2. `batch_begin` is the batch index (an index running over the activity records in the file) at which the requested batch should start.
3. `batch_end` is the index of the last batch that's included in the batch.

These parameters are passed on to the C++ implementation that has been updated to accomodate for them. It still scans the file, which is unavoidable lacking an index of the file's records. However, it keeps a counter of the activity records (the "batches") and starts adding them to the output matrix once it reaches `batch_begin` and stops adding them when it passed `batch_end`, at which point the `while` loop is also stopped, saving a bit of time (more for early batches, less for later batches, since it still has to scan the whole file up until the batch; however, since the goal of this modification is fitting the operation into memory, saving time is just an added bonus, not the main priority).

This PR was designed together with @vincentvanhees.