### PR TITLE
Adding timezone handling functionality

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     R.utils,
     tools
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1
 Suggests: 
     knitr,
     rmarkdown,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     R.utils,
     tools
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 Suggests: 
     knitr,
     rmarkdown,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# read.gt3x 1.2.1
+
+* Added timezone handling functionality, see #43
+
 # read.gt3x 1.2.0
 
 * Added batch-reading functionality, see #40

--- a/R/readGT3X.R
+++ b/R/readGT3X.R
@@ -15,10 +15,8 @@ NULL
 #' @param imputeZeroes Impute zeros in case there are missingness?
 #' Default is FALSE, in which case
 #' the time series will be incomplete in case there is missingness.
-#' @param desiredtz Timezone database name for timezone where accelerometer is
-#'  worn, see note for details.
-#' @param configtz Timezone database name for timezone where accelerometer is
-#' configured, see note for details.
+#' @param desiredtz Timezone where accelerometer was worn, see note for details.
+#' @param configtz Timezone where accelerometer was configured, see note for details.
 #' @param ... additional arguments to pass to \code{parseGT3X} C++ code, e.g. batch-loading options as now documented in vignette "Batch loading a gt3x file"
 #' @param verbose print diagnostic messages
 #' @param cleanup should any unzipped files be deleted?
@@ -36,11 +34,13 @@ NULL
 #' 'GMT' timezone attribute, which is false; the datetime actually
 #' represents local time.
 #'
-#' To change the timezone based on known location of device configuration
-#' and known location of device wear, specify argument desiredtz and configtz.
-#' These take timezone database names as input:
-#'  https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
-#' Here you can specify "" to indicate local timezone.
+#' To interpret the timestamps based on known location of device configuration
+#' and known location of device wear, specify arguments: desiredtz and configtz.
+#' These take Olson timezone database names as character input. For example, "Europe/Helsinki"
+#' See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+#'  or use command OlsonNames() in R for a list of possible timezone names.
+#' Note: You can specify "" to indicate that the timezone of your system
+#' should be used.
 #'
 #' @return A numeric matrix with 3 columns (X, Y, Z) and the following
 #' attributes:
@@ -302,6 +302,7 @@ read.gt3x <- function(path, verbose = FALSE, asDataFrame = FALSE,
     accdata <- as.data.frame(accdata, verbose = verbose > 1)
 
   # Only adjust timezone if user specified desiredtz and/or configtz
+  # In this way default functionality remains unaffected
   if (!is.null(desiredtz) | !is.null(configtz)) {
     # Set equal if one of the two is NULL
     if (is.null(configtz) & !is.null(desiredtz)) {
@@ -314,10 +315,10 @@ read.gt3x <- function(path, verbose = FALSE, asDataFrame = FALSE,
     }
     # Check that timezone names are valid names
     if (desiredtz %in% OlsonNames() == FALSE) {
-      stop(paste0("\n", desiredtz, " is not valid timezone database name"))
+      stop(paste0("\n", desiredtz, " is not a valid timezone database name"))
     }
     if (configtz != desiredtz & configtz %in% OlsonNames() == FALSE) {
-      stop(paste0("\n", configtz, " is not valid timezone database name"))
+      stop(paste0("\n", configtz, " is not a valid timezone database name"))
     }
     # Change timezone
     accdata$time <- lubridate::force_tz(accdata$time, tzone = configtz)

--- a/man/read.gt3x.Rd
+++ b/man/read.gt3x.Rd
@@ -34,11 +34,9 @@ this finds where all 3 axes are zero.}
 
 \item{cleanup}{should any unzipped files be deleted?}
 
-\item{desiredtz}{Timezone database name for timezone where accelerometer is
-worn, see note for details.}
+\item{desiredtz}{Timezone where accelerometer was worn, see note for details.}
 
-\item{configtz}{Timezone database name for timezone where accelerometer is
-configured, see note for details.}
+\item{configtz}{Timezone where accelerometer was configured, see note for details.}
 
 \item{...}{additional arguments to pass to \code{parseGT3X} C++ code, e.g. batch-loading options as now documented in vignette "Batch loading a gt3x file"}
 
@@ -69,11 +67,13 @@ therefore represented as \code{POSIXct} format with the
 'GMT' timezone attribute, which is false; the datetime actually
 represents local time.
 
-To change the timezone based on known location of device configuration
-and known location of device wear, specify argument desiredtz and configtz.
-These take timezone database names as input:
-https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
-Here you can specify "" to indicate local timezone.
+To interpret the timestamps based on known location of device configuration
+and known location of device wear, specify arguments: desiredtz and configtz.
+These take Olson timezone database names as character input. For example, "Europe/Helsinki"
+See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+or use command OlsonNames() in R for a list of possible timezone names.
+Note: You can specify "" to indicate that the timezone of your system
+should be used.
 }
 \examples{
 

--- a/man/read.gt3x.Rd
+++ b/man/read.gt3x.Rd
@@ -11,6 +11,8 @@ read.gt3x(
   imputeZeroes = FALSE,
   flag_idle_sleep = FALSE,
   cleanup = FALSE,
+  desiredtz = NULL,
+  configtz = NULL,
   ...,
   add_light = FALSE
 )
@@ -31,6 +33,12 @@ the time series will be incomplete in case there is missingness.}
 this finds where all 3 axes are zero.}
 
 \item{cleanup}{should any unzipped files be deleted?}
+
+\item{desiredtz}{Timezone database name for timezone where accelerometer is
+worn, see note for details.}
+
+\item{configtz}{Timezone database name for timezone where accelerometer is
+configured, see note for details.}
 
 \item{...}{additional arguments to pass to \code{parseGT3X} C++ code, e.g. batch-loading options as now documented in vignette "Batch loading a gt3x file"}
 
@@ -60,6 +68,12 @@ This is a bit tricky to parse into an R datetime format. DateTimes are
 therefore represented as \code{POSIXct} format with the
 'GMT' timezone attribute, which is false; the datetime actually
 represents local time.
+
+To change the timezone based on known location of device configuration
+and known location of device wear, specify argument desiredtz and configtz.
+These take timezone database names as input:
+https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
+Here you can specify "" to indicate local timezone.
 }
 \examples{
 

--- a/tests/testthat/test-read_old.R
+++ b/tests/testthat/test-read_old.R
@@ -77,3 +77,29 @@ testthat::test_that("Converting Old with .gz file", {
   rm(res)
   rm(df2)
 })
+
+
+tzHel = "Europe/Helsinki"
+tzLon = "Europe/London"
+
+testthat::test_that("read.gt3x old format - timezone configuration == timezone worn (Europe/London)", {
+  gt3xdata_tz_equal <- read.gt3x(path, asDataFrame = TRUE, imputeZeroes = FALSE,
+                                 desiredtz = tzLon, configtz = tzLon)
+  testthat::expect_true(inherits(gt3xdata_tz_equal$time[1], "POSIXct"))
+  testthat::expect_equal(gt3xdata_tz_equal$time[1], as.POSIXct("2012-06-27 10:54:00", tz = tzLon))
+})
+
+testthat::test_that("read.gt3x old format - timezone configuration (Europe/Helsinki) > timezone worn (Europe/London)", {
+  gt3xdata_confidHel_wornLon <- read.gt3x(path, asDataFrame = TRUE, imputeZeroes = FALSE,
+                                         desiredtz = tzLon, configtz = tzHel)
+  testthat::expect_true(inherits(gt3xdata_confidHel_wornLon$time[1], "POSIXct"))
+  testthat::expect_equal(gt3xdata_confidHel_wornLon$time[1], as.POSIXct("2012-06-27 08:54:00", tz = tzLon))
+})
+
+
+testthat::test_that("read.gt3x old format - timezone configuration (Europe/London) < timezone worn (Europe/Helsinki)", {
+  gt3xdata_confidLon_wornHel <- read.gt3x(path, asDataFrame = TRUE, imputeZeroes = FALSE,
+                                          desiredtz = tzHel, configtz = tzLon)
+  testthat::expect_true(inherits(gt3xdata_confidLon_wornHel$time[1], "POSIXct"))
+  testthat::expect_equal(gt3xdata_confidLon_wornHel$time[1], as.POSIXct("2012-06-27 12:54:00", tz = tzHel))
+})

--- a/tests/testthat/test_read_new.R
+++ b/tests/testthat/test_read_new.R
@@ -1,3 +1,4 @@
+
 testthat::context("Reading New data")
 
 csvfile <- system.file(
@@ -152,9 +153,6 @@ testthat::test_that("read.gt3x disables imputing zeroes when using batching", {
   testthat::expect_true(all(gt3xdata_bigger_batch[1:100,] == gt3xdata_batch_impute[1:100,]))
 })
 
-
-
-
 testthat::test_that("read.gt3x - timezone default", {
   testthat::expect_true(inherits(gt3xdata_full$time[1], "POSIXct"))
   testthat::expect_equal(gt3xdata_full$time[1], as.POSIXct("2019-09-17 18:40:00", tz = "GMT"))
@@ -166,25 +164,21 @@ tzLon = "Europe/London"
 testthat::test_that("read.gt3x - timezone configuration == timezone worn (Europe/London)", {
   gt3xdata_tz_equal <- read.gt3x(gt3xfile, asDataFrame = TRUE, imputeZeroes = FALSE,
                                  batch_begin = 1, batch_end = 1, desiredtz = tzLon, configtz = tzLon)
-
   testthat::expect_true(inherits(gt3xdata_tz_equal$time[1], "POSIXct"))
-  testthat::expect_equal(gt3xdata_tz_equal$time[1], as.POSIXct("2019-09-17 18:40:00", tz = "Europe/London"))
+  testthat::expect_equal(gt3xdata_tz_equal$time[1], as.POSIXct("2019-09-17 18:40:00", tz = tzLon))
 })
 
 testthat::test_that("read.gt3x - timezone configuration (Europe/Helsinki) > timezone worn (Europe/London)", {
   gt3xdata_confidHel_wornLon <- read.gt3x(gt3xfile, asDataFrame = TRUE, imputeZeroes = FALSE,
                                           batch_begin = 1, batch_end = 1, desiredtz = tzLon, configtz = tzHel)
-
   testthat::expect_true(inherits(gt3xdata_confidHel_wornLon$time[1], "POSIXct"))
-  testthat::expect_equal(gt3xdata_confidHel_wornLon$time[1], as.POSIXct("2019-09-17 16:40:00", tz = "Europe/London"))
+  testthat::expect_equal(gt3xdata_confidHel_wornLon$time[1], as.POSIXct("2019-09-17 16:40:00", tz = tzLon))
 })
 
 
 testthat::test_that("read.gt3x - timezone configuration (Europe/London) < timezone worn (Europe/Helsinki)", {
-
   gt3xdata_confidLon_wornHel <- read.gt3x(gt3xfile, asDataFrame = TRUE, imputeZeroes = FALSE,
                                           batch_begin = 1, batch_end = 1, desiredtz = tzHel, configtz = tzLon)
-
   testthat::expect_true(inherits(gt3xdata_confidLon_wornHel$time[1], "POSIXct"))
-  testthat::expect_equal(gt3xdata_confidLon_wornHel$time[1], as.POSIXct("2019-09-17 20:40:00", tz = "Europe/Helsinki"))
+  testthat::expect_equal(gt3xdata_confidLon_wornHel$time[1], as.POSIXct("2019-09-17 20:40:00", tz = tzHel))
 })

--- a/tests/testthat/test_read_new.R
+++ b/tests/testthat/test_read_new.R
@@ -1,4 +1,3 @@
-
 testthat::context("Reading New data")
 
 csvfile <- system.file(
@@ -151,4 +150,41 @@ gt3xdata_batch_impute <- read.gt3x(gt3xfile, asDataFrame = TRUE, imputeZeroes=TR
 testthat::test_that("read.gt3x disables imputing zeroes when using batching", {
   testthat::expect_true(nrow(gt3xdata_batch_impute) == nrow(gt3xdata_bigger_batch))
   testthat::expect_true(all(gt3xdata_bigger_batch[1:100,] == gt3xdata_batch_impute[1:100,]))
+})
+
+
+
+
+testthat::test_that("read.gt3x - timezone default", {
+  testthat::expect_true(inherits(gt3xdata_full$time[1], "POSIXct"))
+  testthat::expect_equal(gt3xdata_full$time[1], as.POSIXct("2019-09-17 18:40:00", tz = "GMT"))
+})
+
+tzHel = "Europe/Helsinki"
+tzLon = "Europe/London"
+
+testthat::test_that("read.gt3x - timezone configuration == timezone worn (Europe/London)", {
+  gt3xdata_tz_equal <- read.gt3x(gt3xfile, asDataFrame = TRUE, imputeZeroes = FALSE,
+                                 batch_begin = 1, batch_end = 1, desiredtz = tzLon, configtz = tzLon)
+
+  testthat::expect_true(inherits(gt3xdata_tz_equal$time[1], "POSIXct"))
+  testthat::expect_equal(gt3xdata_tz_equal$time[1], as.POSIXct("2019-09-17 18:40:00", tz = "Europe/London"))
+})
+
+testthat::test_that("read.gt3x - timezone configuration (Europe/Helsinki) > timezone worn (Europe/London)", {
+  gt3xdata_confidHel_wornLon <- read.gt3x(gt3xfile, asDataFrame = TRUE, imputeZeroes = FALSE,
+                                          batch_begin = 1, batch_end = 1, desiredtz = tzLon, configtz = tzHel)
+
+  testthat::expect_true(inherits(gt3xdata_confidHel_wornLon$time[1], "POSIXct"))
+  testthat::expect_equal(gt3xdata_confidHel_wornLon$time[1], as.POSIXct("2019-09-17 16:40:00", tz = "Europe/London"))
+})
+
+
+testthat::test_that("read.gt3x - timezone configuration (Europe/London) < timezone worn (Europe/Helsinki)", {
+
+  gt3xdata_confidLon_wornHel <- read.gt3x(gt3xfile, asDataFrame = TRUE, imputeZeroes = FALSE,
+                                          batch_begin = 1, batch_end = 1, desiredtz = tzHel, configtz = tzLon)
+
+  testthat::expect_true(inherits(gt3xdata_confidLon_wornHel$time[1], "POSIXct"))
+  testthat::expect_equal(gt3xdata_confidLon_wornHel$time[1], as.POSIXct("2019-09-17 20:40:00", tz = "Europe/Helsinki"))
 })

--- a/tests/testthat/test_read_new.R
+++ b/tests/testthat/test_read_new.R
@@ -182,3 +182,14 @@ testthat::test_that("read.gt3x - timezone configuration (Europe/London) < timezo
   testthat::expect_true(inherits(gt3xdata_confidLon_wornHel$time[1], "POSIXct"))
   testthat::expect_equal(gt3xdata_confidLon_wornHel$time[1], as.POSIXct("2019-09-17 20:40:00", tz = tzHel))
 })
+
+old <- options(warn = 1)
+testthat::test_that("read.gt3x - timezone handling produces expected errors and warnings", {
+  expect_error(read.gt3x(gt3xfile, asDataFrame = TRUE, imputeZeroes = FALSE,
+                                          batch_begin = 1, batch_end = 1, desiredtz = "invalidname", configtz = tzLon), "invalidname is not a valid timezone database name")
+
+  expect_warning(read.gt3x(gt3xfile, asDataFrame = TRUE, imputeZeroes = FALSE,
+                         batch_begin = 1, batch_end = 1, desiredtz = tzHel, configtz = NULL), "configtz not specified, now assumed to equal desiredtz")
+
+})
+options(old)


### PR DESCRIPTION
This PR adds timezone handling, see issue #43.

1. Two new input arguments:
  - `configtz` => the timezone where the accelerometer was configured.
  - `desiredtz` => the timezone where the accelerometer was worn.

I am using the names `configtz` and `desiredtz` because that is the terminology I have been using in R package GGIR. However, we are of course not bound by those names. So, if you prefer alternative more intuitive names then we can do that. For example: `tz_worn` and `tz_config`.

2. To preserve consistency with previous read.gt3x releases, the default behaviour with `configtz=NULL` and `desiredtz=NULL` leaves default tz `GMT` untouched.
3. Added unit tests for timestamp covering both old- and new .gt3x format.
4. Gives warning when only one of the two timezone arguments is specified, and then assumes that the unspecified tz equals the specified tz.
5. Gives error if timezone name is not in `OlsenNames()`.
6. Added unit tests for this warning (4) and error (5).
