### PR TITLE
BUG: Parse info not passing `tz`

### DIFF
--- a/R/gt3x_info.R
+++ b/R/gt3x_info.R
@@ -32,7 +32,7 @@ parse_gt3x_info <- function(path, tz = "GMT") {
       verbose = FALSE)
     on.exit(unlink(path, recursive = TRUE))
   }
-  extract_gt3x_info(file.path(path, "info.txt"))
+  extract_gt3x_info(file.path(path, "info.txt"), tz = tz)
 }
 
 #' @export


### PR DESCRIPTION
BUG: fixing it so you can pass `tz` to `extract_gt3x_info`.